### PR TITLE
chore: align Vercel config and Node engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "car-detective-mvp-monorepo",
   "private": true,
+  "engines": {
+    "node": ">=18"
+  },
   "workspaces": [
     "apps/*"
   ],

--- a/vercel.json
+++ b/vercel.json
@@ -1,18 +1,6 @@
 {
   "version": 2,
-  "builds": [
-    { "src": "apps/ain-valuation-engine/api/**/*.py", "use": "@vercel/python" },
-    {
-      "src": "apps/ain-valuation-engine/package.json",
-      "use": "@vercel/static-build",
-      "config": { "distDir": "dist" }
-    }
-  ],
-  "routes": [
-    { "src": "^/api$", "dest": "/apps/ain-valuation-engine/api/app.py" },
-    { "src": "^/api/(.*)$", "dest": "/apps/ain-valuation-engine/api/app.py" }
-  ],
-  "installCommand": "npm install",
+  "installCommand": "npm ci",
   "buildCommand": "npm run build --workspace apps/ain-valuation-engine",
   "outputDirectory": "apps/ain-valuation-engine/dist"
 }


### PR DESCRIPTION
## Summary
- add an engines field that enforces Node.js 18+ at the workspace root
- simplify the root Vercel configuration to the minimal commands for building the ain valuation engine app

## Testing
- not run (configuration-only changes)


------
https://chatgpt.com/codex/tasks/task_b_68cb10e78248832db2033c70d2274732