### PR TITLE
fix: restore canonical valuation types

### DIFF
--- a/apps/ain-valuation-engine/src/types/ValuationTypes.ts
+++ b/apps/ain-valuation-engine/src/types/ValuationTypes.ts
@@ -1,19 +1,12 @@
 
 // src/types/ValuationTypes.ts
 // Canonical schema. Single source of truth comes from ./canonical.
-import type { VehicleDataCanonical } from './canonical'
-export type { VehicleDataCanonical } from './canonical'
-
+import type { VehicleData, VehicleDataCanonical } from './canonical'
+export type { VehicleData, VehicleDataCanonical } from './canonical'
+export { toCanonicalVehicleData } from './canonical'
 // Keep alias for legacy imports
-export type VehicleData = VehicleDataCanonical;
-/**
- * @deprecated Use VehicleDataCanonical instead.
- */
-export type LegacyVehicleData = VehicleDataCanonical;
-/**
- * @deprecated Use ValuationResultCanonical instead.
- */
-export type ValuationResult = ValuationResultCanonical;
+export type LegacyVehicleData = VehicleDataCanonical
+export type ValuationResult = ValuationResultCanonical
 
 /**
  * Runtime-friendly vehicle condition options used throughout the valuation UI.
@@ -161,3 +154,5 @@ export interface VehicleHistory {
   titleHistory: TitleRecord[];
   recallHistory: RecallRecord[];
 }
+
+// Do not redeclare VehicleData/VehicleDataCanonical here. They come from ./canonical.

--- a/apps/ain-valuation-engine/src/types/canonical.ts
+++ b/apps/ain-valuation-engine/src/types/canonical.ts
@@ -31,7 +31,7 @@ export function toCanonicalVehicleData(input: Partial<VehicleData>): VehicleData
     make: req(input.make, 'make'),
     model: req(input.model, 'model'),
     mileage: req(input.mileage, 'mileage'),
-    zip: req(input.zip, 'zip'),
+    zip: req((input as any).zip ?? (input as any).zipCode, 'zip'),
     condition: req(input.condition, 'condition'),
     titleStatus: req(input.titleStatus, 'titleStatus'),
     trim: input.trim,


### PR DESCRIPTION
## Summary
- re-export the canonical VehicleData types and converter through ValuationTypes to remove merge artefacts
- document that the canonical schema now centralizes VehicleData definitions
- allow toCanonicalVehicleData to read zip codes from either zip or zipCode fields to keep existing callers working

## Testing
- pnpm --dir apps/ain-valuation-engine exec tsc --noEmit
- npm run -w apps/ain-valuation-engine build

------
https://chatgpt.com/codex/tasks/task_b_68cc34398e10832d9797ecaf81a96050