### PR TITLE
Add runtime zip guard for valuation engine

### DIFF
--- a/apps/ain-valuation-engine/src/ain-backend/valuationEngine.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/valuationEngine.ts
@@ -7,6 +7,9 @@ import type { VehicleData, ValuationResult } from '@/types/ValuationTypes'
  * Delegates to the service layer, supporting legacy names.
  */
 export async function valuateVehicle(data: VehicleData): Promise<ValuationResult> {
+  if (process.env.NODE_ENV !== 'production' && (data as any).zip === undefined) {
+    throw new Error('valuateVehicle: zip is required in VehicleDataCanonical')
+  }
   const fn =
     (svc as any).valuateVehicle ??
     (svc as any).processValuation ??

--- a/apps/ain-valuation-engine/src/components/result/ValuationResultsDisplay.tsx
+++ b/apps/ain-valuation-engine/src/components/result/ValuationResultsDisplay.tsx
@@ -126,7 +126,7 @@ export function ValuationResultsDisplay(props: ValuationResultsProps) {
             <strong>Title Status:</strong> {String(valuation.vehicleData?.titleStatus ?? 'N/A')}
           </div>
           <div>
-            <strong>Location:</strong> {valuation.vehicleData?.zipCode || 'N/A'}
+            <strong>Location:</strong> {valuation.vehicleData?.zip ?? 'N/A'}
           </div>
         </div>
       </div>

--- a/apps/ain-valuation-engine/src/types_custom/valuation.ts
+++ b/apps/ain-valuation-engine/src/types_custom/valuation.ts
@@ -6,7 +6,7 @@ export interface ValuationInputs {
   trim?: string;
   currentMileage?: number;
   condition?: string;
-  zipCode?: string;
+  zip?: string;
 }
 
 // Main valuation interfaces and types
@@ -51,5 +51,5 @@ export interface EnrichedVehicleProfile {
 
   currentMileage?: number;
   condition?: string;
-  zipCode?: string;
+  zip?: string;
 }


### PR DESCRIPTION
## Summary
- add a development-only runtime assertion that ensures VehicleData payloads include a zip before calling the valuation service
- align the valuation results display and legacy valuation types with the canonical zip field

## Testing
- npm run typecheck:fast
- npm run -w apps/ain-valuation-engine build

------
https://chatgpt.com/codex/tasks/task_b_68cc31d64ff8832db2e32877a4c11785