### PR TITLE
Refine normalization types for valuation backend

### DIFF
--- a/apps/ain-valuation-engine/src/ain-backend/server.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/server.ts
@@ -2,7 +2,7 @@
 
 import express from "express";
 import cors from "cors";
-import { normalizeVehicleData } from "../services/normalizeVehicleData.js";
+import { normalizeVehicleData, type NormalizedVehicleData } from "../services/normalizeVehicleData.js";
 import logger from "../utils/logger.js";
 import { carApiService } from "../services/carApiService.js";
 import { vinLookupService } from "../services/vinLookupService.js";
@@ -47,7 +47,16 @@ app.post("/api/valuate", async (req, res) => {
     logger.info(`[AUDIT] Validation OK`);
 
     // Normalize vehicle data for all services
-    const vehicle = normalizeVehicleData({ vin, year, make, model, mileage, zip, condition, titleStatus });
+    const vehicle: NormalizedVehicleData = normalizeVehicleData({
+      vin,
+      year,
+      make,
+      model,
+      mileage,
+      zip,
+      condition,
+      titleStatus
+    });
 
     // Decode VINs (pass vehicle object)
     let decodeSource = 'NONE';

--- a/apps/ain-valuation-engine/src/ain-backend/supabaseClient.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/supabaseClient.ts
@@ -1,6 +1,6 @@
 import { createClient } from "@supabase/supabase-js";
 import logger from "../utils/logger.js";
-type VehicleData = any; type SessionData = any;
+import type { VehicleData, SessionData } from "@/types/ValuationTypes";
 
 const supabaseUrl = process.env.SUPABASE_URL || "";
 const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || "";

--- a/apps/ain-valuation-engine/src/services/normalizeVehicleData.ts
+++ b/apps/ain-valuation-engine/src/services/normalizeVehicleData.ts
@@ -1,7 +1,8 @@
 import * as z from "zod";
+import type { VehicleData } from "@/types/ValuationTypes";
 
 // Define the Zod schema for vehicle data (MVP, minimal fields)
-export const VehicleDataSchema = z.object({
+export const NormalizedVehicleDraftSchema = z.object({
   vin: z.string()
     .length(17, "VIN must be 17 characters")
     .regex(/^[A-HJ-NPR-Z0-9]+$/, "VIN contains invalid characters"),
@@ -16,12 +17,14 @@ export const VehicleDataSchema = z.object({
 });
 
 // TypeScript type inferred from schema
-export type VehicleData = z.infer<typeof VehicleDataSchema>;
+export type NormalizedVehicleDraft = z.infer<typeof NormalizedVehicleDraftSchema>;
+
+export type NormalizedVehicleData = Partial<VehicleData> & NormalizedVehicleDraft;
 
 // Normalization function: validates and returns typed object
-export function normalizeVehicleData(input: unknown): VehicleData {
+export function normalizeVehicleData(input: unknown): NormalizedVehicleDraft {
   try {
-    return VehicleDataSchema.parse(input);
+    return NormalizedVehicleDraftSchema.parse(input);
   } catch (err: any) {
     throw new Error(`Invalid vehicle data: ${err.message}`);
   }


### PR DESCRIPTION
## Summary
- rename the vehicle normalization schema to `NormalizedVehicleDraft` and expose a `NormalizedVehicleData` helper that composes the canonical `VehicleData`
- update the valuation server to annotate normalized payloads with the new helper type
- type supabase session and vehicle helpers with the shared `VehicleData` and `SessionData` definitions

## Testing
- npm run typecheck:fast

------
https://chatgpt.com/codex/tasks/task_b_68cc7ec85f58832daf7b04d682659cc1