### PR TITLE
Normalize valuation engine TypeScript imports

### DIFF
--- a/apps/ain-valuation-engine/mvp-backend/server.ts
+++ b/apps/ain-valuation-engine/mvp-backend/server.ts
@@ -1,13 +1,13 @@
 import express from "express";
 import cors from "cors";
-import { normalizeVehicleData } from "./normalizeVehicleData.js";
-import logger from "./logger.js";
-import { carApiService } from "./carApiService.js";
-import { vinLookupService } from "./vinLookupService.js";
-import { vehiclePricingService } from "./vehiclePricingService.js";
-import { residualValueService } from "./residualValueService.js";
-import { carSpecsService } from "./carSpecsService.js";
-import { decodeVinAndEstimate } from "./vinValuationService.js";
+import { normalizeVehicleData } from "./normalizeVehicleData";
+import logger from "./logger";
+import { carApiService } from "./carApiService";
+import { vinLookupService } from "./vinLookupService";
+import { vehiclePricingService } from "./vehiclePricingService";
+import { residualValueService } from "./residualValueService";
+import { carSpecsService } from "./carSpecsService";
+import { decodeVinAndEstimate } from "./vinValuationService";
 
 const app = express();
 app.use(cors());

--- a/apps/ain-valuation-engine/src/ain-backend/conversationApi.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/conversationApi.ts
@@ -1,5 +1,5 @@
 import express from "express";
-import { ConversationEngine } from "./conversationEngine.js";
+import { ConversationEngine } from "./conversationEngine";
 
 const router = express.Router();
 

--- a/apps/ain-valuation-engine/src/ain-backend/conversationEngine.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/conversationEngine.ts
@@ -1,4 +1,4 @@
-import { decodeVin, isVinDecodeSuccessful, extractLegacyVehicleInfo } from '../services/unifiedVinDecoder.js'
+import { decodeVin, isVinDecodeSuccessful, extractLegacyVehicleInfo } from '../services/unifiedVinDecoder'
 import { valuateVehicle } from '@/ain-backend/valuationEngine'
 import type { VehicleData, VehicleDataCanonical, ValuationResult } from '@/types/ValuationTypes'
 import { toCanonicalVehicleData } from '@/types/canonical'

--- a/apps/ain-valuation-engine/src/ain-backend/gpt4oService.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/gpt4oService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 type AIContext = any;
 
 const openai = new OpenAI({

--- a/apps/ain-valuation-engine/src/ain-backend/server.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/server.ts
@@ -2,14 +2,14 @@
 
 import express from "express";
 import cors from "cors";
-import { normalizeVehicleData } from "../services/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
-import { carApiService } from "../services/carApiService.js";
-import { vinLookupService } from "../services/vinLookupService.js";
+import { normalizeVehicleData } from "../services/normalizeVehicleData";
+import logger from "../utils/logger";
+import { carApiService } from "../services/carApiService";
+import { vinLookupService } from "../services/vinLookupService";
 import axios from "axios";
-import { residualValueService } from "../services/residualValueService.js";
-import { carSpecsService } from "../services/carSpecsService.js";
-import { decodeVinAndEstimate } from "../services/vinValuationService.js";
+import { residualValueService } from "../services/residualValueService";
+import { carSpecsService } from "../services/carSpecsService";
+import { decodeVinAndEstimate } from "../services/vinValuationService";
 
 
 const app = express();

--- a/apps/ain-valuation-engine/src/ain-backend/supabaseClient.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/supabaseClient.ts
@@ -1,5 +1,5 @@
 import { createClient } from "@supabase/supabase-js";
-import logger from "../utils/logger.js";
+import logger from "../utils/logger";
 type VehicleData = any; type SessionData = any;
 
 const supabaseUrl = process.env.SUPABASE_URL || "";

--- a/apps/ain-valuation-engine/src/ain-backend/vinDecoder.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/vinDecoder.ts
@@ -1,4 +1,4 @@
-import { decodeVin, extractLegacyVehicleInfo, isVinDecodeSuccessful } from '../services/unifiedVinDecoder.js';
+import { decodeVin, extractLegacyVehicleInfo, isVinDecodeSuccessful } from '../services/unifiedVinDecoder';
 
 export async function decodeVIN(vin: string) {
   const result = await decodeVin(vin);

--- a/apps/ain-valuation-engine/src/ain-backend/visionService.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/visionService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 
 const openai = new OpenAI({
   apiKey: process.env.VITE_OPENAI_API_KEY || process.env.OPENAI_API_KEY,

--- a/apps/ain-valuation-engine/src/ain-backend/whisperService.ts
+++ b/apps/ain-valuation-engine/src/ain-backend/whisperService.ts
@@ -1,5 +1,5 @@
 import OpenAI from 'openai';
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 import fs from 'fs';
 import path from 'path';
 

--- a/apps/ain-valuation-engine/src/services/carApiService.ts
+++ b/apps/ain-valuation-engine/src/services/carApiService.ts
@@ -1,5 +1,5 @@
-import { NormalizedVehicle } from "../utils/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
+import { NormalizedVehicle } from "../utils/normalizeVehicleData";
+import logger from "../utils/logger";
 
 export async function carApiService(vehicle: NormalizedVehicle): Promise<{ [key: string]: any }> {
   logger.info("Calling Car API Service", { vin: vehicle.vin });

--- a/apps/ain-valuation-engine/src/services/carSpecsService.ts
+++ b/apps/ain-valuation-engine/src/services/carSpecsService.ts
@@ -1,5 +1,5 @@
-import { NormalizedVehicle } from "../utils/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
+import { NormalizedVehicle } from "../utils/normalizeVehicleData";
+import logger from "../utils/logger";
 
 export async function carSpecsService(
   vehicle: NormalizedVehicle

--- a/apps/ain-valuation-engine/src/services/fuelEconomyService.ts
+++ b/apps/ain-valuation-engine/src/services/fuelEconomyService.ts
@@ -1,7 +1,7 @@
 // src/services/fuelEconomyService.ts
 import { ExternalApiService } from './centralizedApi';
 import { ConfigService } from './centralizedApi';
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 import { apiCallsTotal } from '../utils/metrics';
 
 export interface FuelEconomyData {

--- a/apps/ain-valuation-engine/src/services/geo/ZipGeo.ts
+++ b/apps/ain-valuation-engine/src/services/geo/ZipGeo.ts
@@ -1,4 +1,4 @@
-import { supabase } from "../../db/supabaseClient.js";
+import { supabase } from "../../db/supabaseClient";
 
 export type ZipPoint = { zip: string; lat: number; lon: number };
 const cache = new Map<string, ZipPoint>();

--- a/apps/ain-valuation-engine/src/services/marketAgents/OpenAIListingsFetcher.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/OpenAIListingsFetcher.ts
@@ -1,13 +1,12 @@
 // @ts-nocheck
 import got = require("got");
-import { extractListingsFromHtml } from "./extractors/openaiExtractor.js";
-import { extractListingsFromHtml } from "./extractors/openaiExtractor.js";
-import type { Listing } from "./schemas/ListingSchema.js";
-import { cleanNumbers } from "./utils/numbers.js";
-import { toIso } from "./utils/time.js";
-import { isAllowedHost, getHostPolicy, getHostCacheTtlMs } from "./config/sources.js";
-import { limiterFor } from "./utils/throttle.js";
-import { getCached, setCached } from "./utils/cache.js";
+import { extractListingsFromHtml } from "./extractors/openaiExtractor";
+import type { Listing } from "./schemas/ListingSchema";
+import { cleanNumbers } from "./utils/numbers";
+import { toIso } from "./utils/time";
+import { isAllowedHost, getHostPolicy, getHostCacheTtlMs } from "./config/sources";
+import { limiterFor } from "./utils/throttle";
+import { getCached, setCached } from "./utils/cache";
 
 export async function fetchAndExtract(urls: string[], model = "gpt-4o-mini"): Promise<Listing[]> {
 

--- a/apps/ain-valuation-engine/src/services/marketAgents/config/sources.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/config/sources.ts
@@ -1,6 +1,6 @@
 // Lightweight loader for the allowlisted sources.
 // Only domains with allowed=true will be queried.
-import { SOURCES_DATA } from "./sourcesData.js";
+import { SOURCES_DATA } from "./sourcesData";
 export type SourcePolicy = { allowed: boolean; maxConcurrent?: number; minDelayMs?: number; freshnessDays?: number; cacheTtlMs?: number };
 export function getHostFreshnessDays(hostname: string): number {
   const h = hostname.replace(/^www\./, "");

--- a/apps/ain-valuation-engine/src/services/marketAgents/openaiSearchStructured.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/openaiSearchStructured.ts
@@ -1,5 +1,5 @@
 import OpenAI from "openai";
-import { MarketListingArraySchema } from "./prompts/kit.js";
+import { MarketListingArraySchema } from "./prompts/kit";
 
 const client = new OpenAI({ apiKey: process.env.OPENAI_API_KEY! });
 

--- a/apps/ain-valuation-engine/src/services/marketAgents/persistence/runLogs.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/persistence/runLogs.ts
@@ -1,4 +1,4 @@
-import { supabase } from "../../../db/supabaseClient.js";
+import { supabase } from "../../../db/supabaseClient";
 
 export async function createRunLog(params: {
   run_id: string;

--- a/apps/ain-valuation-engine/src/services/marketAgents/persistence/upsertListings.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/persistence/upsertListings.ts
@@ -1,6 +1,6 @@
-import { supabase } from "../../../db/supabaseClient.js";
-import type { Listing } from "../schemas/ListingSchema.js";
-import { stableKey } from "../utils/dedupe.js";
+import { supabase } from "../../../db/supabaseClient";
+import type { Listing } from "../schemas/ListingSchema";
+import { stableKey } from "../utils/dedupe";
 
 export async function upsertListings(rows: Listing[]): Promise<number> {
   if (!rows.length) return 0;

--- a/apps/ain-valuation-engine/src/services/marketAgents/retail/OpenAIListingsAgent.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/retail/OpenAIListingsAgent.ts
@@ -1,11 +1,11 @@
-import { searchInBatches } from "../aggregateSearch.js";
-import { dedupeListings } from "../utils/dedupeIngest.js";
-import { filterFresh } from "../filters.js";
-import { carsDotCom, carGurus, autoTrader, trueCar, edmunds } from "../utils/urls.js";
-import type { Listing } from "../schemas/ListingSchema.js";
-import { upsertListings } from "../persistence/upsertListings.js";
-import { createRunLog, finishRunLog } from "../persistence/runLogs.js";
-import { filterForValuation } from "../utils/sanity.js";
+import { searchInBatches } from "../aggregateSearch";
+import { dedupeListings } from "../utils/dedupeIngest";
+import { filterFresh } from "../filters";
+import { carsDotCom, carGurus, autoTrader, trueCar, edmunds } from "../utils/urls";
+import type { Listing } from "../schemas/ListingSchema";
+import { upsertListings } from "../persistence/upsertListings";
+import { createRunLog, finishRunLog } from "../persistence/runLogs";
+import { filterForValuation } from "../utils/sanity";
 
 export class OpenAIListingsAgent {
   async run({ zip="94103", radius=100, make, model, year }: {

--- a/apps/ain-valuation-engine/src/services/marketAgents/router.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/router.ts
@@ -1,4 +1,4 @@
-import { listHostsByTier } from "./config/policy.js";
+import { listHostsByTier } from "./config/policy";
 
 export type RouteParams = { locale?: "us"|"intl"; vin?: string|null; make?:string; model?:string; year?:number; zip?:string; radius?:number };
 

--- a/apps/ain-valuation-engine/src/services/marketAgents/utils/dedupe.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/utils/dedupe.ts
@@ -1,5 +1,5 @@
 import * as crypto from "crypto";
-import type { Listing } from "../schemas/ListingSchema.js";
+import type { Listing } from "../schemas/ListingSchema";
 
 export function stableKey(l: Listing) {
   const approxPrice = l.price == null ? "" : Math.round(l.price / 100) * 100;

--- a/apps/ain-valuation-engine/src/services/marketAgents/utils/sanity.ts
+++ b/apps/ain-valuation-engine/src/services/marketAgents/utils/sanity.ts
@@ -1,5 +1,5 @@
-import type { Listing } from "../schemas/ListingSchema.js";
-import { iqrBounds, median } from "./stats.js";
+import type { Listing } from "../schemas/ListingSchema";
+import { iqrBounds, median } from "./stats";
 
 export type FilterReport = {
   kept: Listing[];

--- a/apps/ain-valuation-engine/src/services/residualValueService.ts
+++ b/apps/ain-valuation-engine/src/services/residualValueService.ts
@@ -1,5 +1,5 @@
-import { NormalizedVehicle } from "../utils/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
+import { NormalizedVehicle } from "../utils/normalizeVehicleData";
+import logger from "../utils/logger";
 
 export async function residualValueService(
   vehicle: NormalizedVehicle

--- a/apps/ain-valuation-engine/src/services/unifiedSupabase.ts
+++ b/apps/ain-valuation-engine/src/services/unifiedSupabase.ts
@@ -3,7 +3,7 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { ConfigService } from './centralizedApi';
 import { VehicleData, SessionData } from '@/types/ValuationTypes';
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 
 // Singleton pattern for client instances
 class SupabaseManager {

--- a/apps/ain-valuation-engine/src/services/unifiedVinDecoder.ts
+++ b/apps/ain-valuation-engine/src/services/unifiedVinDecoder.ts
@@ -3,7 +3,7 @@
  * Consolidates all VIN decoding logic with proper fallback handling
  */
 
-import { validateVIN } from './vinValidation.js';
+import { validateVIN } from './vinValidation';
 
 // Types for VIN decoding response
 export interface DecodedVinData {

--- a/apps/ain-valuation-engine/src/services/valuation/CohortStats.ts
+++ b/apps/ain-valuation-engine/src/services/valuation/CohortStats.ts
@@ -1,6 +1,6 @@
-import { supabase } from "../../db/supabaseClient.js";
-import { median } from "../marketAgents/utils/stats.js";
-import { getZipPoint, haversineMiles } from "../geo/ZipGeo.js";
+import { supabase } from "../../db/supabaseClient";
+import { median } from "../marketAgents/utils/stats";
+import { getZipPoint, haversineMiles } from "../geo/ZipGeo";
 
 export async function getCohortStats(params: {
   make: string;

--- a/apps/ain-valuation-engine/src/services/vehiclePricingService.ts
+++ b/apps/ain-valuation-engine/src/services/vehiclePricingService.ts
@@ -1,5 +1,5 @@
-import { NormalizedVehicle } from "../utils/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
+import { NormalizedVehicle } from "../utils/normalizeVehicleData";
+import logger from "../utils/logger";
 
 export async function vehiclePricingService(
   vehicle: NormalizedVehicle

--- a/apps/ain-valuation-engine/src/services/vinLookupService.ts
+++ b/apps/ain-valuation-engine/src/services/vinLookupService.ts
@@ -1,5 +1,5 @@
-import { NormalizedVehicle } from "../utils/normalizeVehicleData.js";
-import logger from "../utils/logger.js";
+import { NormalizedVehicle } from "../utils/normalizeVehicleData";
+import logger from "../utils/logger";
 
 export async function vinLookupService(
   vehicle: NormalizedVehicle

--- a/apps/ain-valuation-engine/src/services/vinValuationService.ts
+++ b/apps/ain-valuation-engine/src/services/vinValuationService.ts
@@ -1,7 +1,7 @@
 
 import axios from 'axios';
 
-import logger from '../utils/logger.js';
+import logger from '../utils/logger';
 export async function decodeVinAndEstimate(vin: string) {
   const cleanVin = vin.trim().toUpperCase();
   if (!cleanVin || cleanVin.length !== 17) throw new Error('Invalid VIN');

--- a/apps/ain-valuation-engine/src/utils/logger.ts
+++ b/apps/ain-valuation-engine/src/utils/logger.ts
@@ -1,2 +1,2 @@
-import logger from './logger-browser.js';
+import logger from './logger-browser';
 export default logger;


### PR DESCRIPTION
## Summary
- replace `.js` relative imports across the AIN valuation backend and services with extensionless TypeScript module references
- align market agent utilities with their TypeScript sources and remove the duplicate extractor import in the OpenAI listings fetcher

## Testing
- npm run typecheck:fast

------
https://chatgpt.com/codex/tasks/task_b_68cc7ee008b0832db0ade2e99c68fc53