### PR TITLE
chore: update api dependencies for security

### DIFF
--- a/apps/ain-valuation-engine/api/requirements.txt
+++ b/apps/ain-valuation-engine/api/requirements.txt
@@ -1,6 +1,6 @@
-Flask==2.0.3
-Werkzeug==2.0.3
-requests==2.31.0
+Flask==2.3.3
+Werkzeug==3.1.3
+requests==2.32.3
 python-dotenv==1.0.0
 setuptools>=68
 wheel>=0.41

--- a/apps/ain-valuation-engine/requirements.txt
+++ b/apps/ain-valuation-engine/requirements.txt
@@ -144,7 +144,7 @@ PyYAML==6.0.2
 pyzmq==27.0.0
 realtime==1.0.5
 referencing==0.36.2
-requests==2.31.0
+requests==2.32.3
 rfc3339-validator==0.1.4
 rfc3986-validator==0.1.1
 rich==14.1.0


### PR DESCRIPTION
## Summary
- bump the API Flask stack to patched releases to resolve Dependabot alerts
- align the monorepo requirements with requests 2.32.3

## Testing
- pip install -r apps/ain-valuation-engine/api/requirements.txt


------
https://chatgpt.com/codex/tasks/task_b_68cd8c9731e8832da7905b426d34b9c9