### PR TITLE
Fix Supabase valuation flow

### DIFF
--- a/apps/ain-valuation-engine/src/scripts/run-audit.mts
+++ b/apps/ain-valuation-engine/src/scripts/run-audit.mts
@@ -1,4 +1,4 @@
-import runAudit from "../tools/audit/AuditRunner.ts";
+import runAudit from "../tools/audit/AuditRunner";
 
 (async () => {
   await runAudit();

--- a/src/hooks/useCorrectedValuation.ts
+++ b/src/hooks/useCorrectedValuation.ts
@@ -57,17 +57,23 @@ export function useCorrectedValuation() {
       logger.log("ain.val.ms", Math.round(performance.now()-t0), { route: meta.route, corr_id: meta.corr_id });
       
       // Convert to expected format
+      const finalValue = ainResult.finalValue ?? ainResult.estimated_value ?? 0;
+      const confidenceScore = ainResult.confidenceScore ?? ainResult.confidence_score ?? 0;
+      const priceRange: [number, number] = ainResult.priceRange
+        ? [ainResult.priceRange[0] ?? finalValue, ainResult.priceRange[1] ?? finalValue]
+        : [ainResult.price_range_low ?? finalValue, ainResult.price_range_high ?? finalValue];
+
       const formattedResults: CorrectedValuationResults = {
         success: true,
         valuation: {
-          estimatedValue: ainResult.estimated_value || 0,
-          confidenceScore: ainResult.confidence_score || 0,
-          basePrice: ainResult.base_value || ainResult.estimated_value || 0,
-          adjustments: ainResult.adjustments || [],
-          priceRange: [ainResult.price_range_low || 0, ainResult.price_range_high || 0],
+          estimatedValue: finalValue,
+          confidenceScore,
+          basePrice: ainResult.base_value ?? finalValue,
+          adjustments: ainResult.adjustments ?? ainResult.breakdown ?? [],
+          priceRange,
           marketAnalysis: {
             dataSource: 'ain',
-            listingCount: 0
+            listingCount: ainResult.marketListingsCount ?? 0
           }
         }
       };

--- a/src/hooks/useDealerOfferActions.ts
+++ b/src/hooks/useDealerOfferActions.ts
@@ -59,7 +59,7 @@ export function useDealerOfferActions() {
       // Optional: Log acceptance for AIN learning
       if (options.valuationId) {
         const { data: valuationData } = await supabase
-          .from('valuations')
+          .from('valuation_results')
           .select('estimated_value, zip_code')
           .eq('id', options.valuationId)
           .single();

--- a/src/hooks/useFollowUpForm.ts
+++ b/src/hooks/useFollowUpForm.ts
@@ -146,17 +146,24 @@ export function useFollowUpForm(vin: string, initialData?: Partial<FollowUpAnswe
         logger.log("ain.val.ms", Math.round(performance.now()-t0), { route: meta.route, corr_id: meta.corr_id });
         
         // Convert AIN result to expected format with all required fields
+        const finalValue = ainResult.finalValue ?? ainResult.estimated_value ?? 0;
+        const confidenceScore = ainResult.confidenceScore ?? ainResult.confidence_score ?? 0;
+        const priceRange = (ainResult.priceRange && ainResult.priceRange.length === 2)
+          ? [ainResult.priceRange[0] ?? finalValue, ainResult.priceRange[1] ?? finalValue] as [number, number]
+          : [ainResult.price_range_low ?? finalValue, ainResult.price_range_high ?? finalValue] as [number, number];
+        const adjustments = ainResult.adjustments ?? ainResult.breakdown ?? [];
+
         const valuationResult = {
-          finalValue: ainResult.estimated_value || 0,
-          estimatedValue: ainResult.estimated_value || 0,
-          confidenceScore: ainResult.confidence_score || 0,
-          breakdown: ainResult.breakdown || [],
+          finalValue,
+          estimatedValue: finalValue,
+          confidenceScore,
+          breakdown: adjustments,
           marketData: ainResult.market_data || {},
           explanation: ainResult.explanation || 'Professional valuation from AIN API',
           source: 'ain',
           metadata: meta,
-          priceRange: [ainResult.price_range_low || 0, ainResult.price_range_high || 0] as [number, number],
-          adjustments: ainResult.adjustments || []
+          priceRange,
+          adjustments
         };
 
         if (valuationResult.finalValue > 0) {

--- a/src/lib/ainClient.ts
+++ b/src/lib/ainClient.ts
@@ -1,21 +1,82 @@
+import { createClient } from '@supabase/supabase-js';
+
 // Hardened AIN client for professional valuations
-export type AinMeta = { 
-  route?: string; 
-  corr_id?: string | null; 
-  upstream_status?: string | null 
+export type AinMeta = {
+  route?: string;
+  corr_id?: string | null;
+  upstream_status?: string | null
 };
 
-export type AinResponse = {
+type NormalizedValuationResponse = {
+  finalValue?: number;
+  priceRange?: [number, number];
+  confidenceScore?: number;
+  adjustments?: any[];
+  explanation?: string;
+  marketListingsCount?: number;
+  sourcesUsed?: string[];
+  baseValue?: number;
+  market_data?: Record<string, unknown>;
+};
+
+export type AinResponse = NormalizedValuationResponse & {
   estimated_value: number;
   confidence_score: number;
-  breakdown?: any[];
-  market_data?: Record<string, unknown>;
-  explanation?: string;
   price_range_low?: number;
   price_range_high?: number;
+  price_range?: [number, number];
+  breakdown?: any[];
+  market_data?: Record<string, unknown>;
   base_value?: number;
-  adjustments?: any[];
 };
+
+const supabaseUrl = import.meta.env.VITE_SUPABASE_URL;
+const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+
+const supabase = supabaseUrl && supabaseAnonKey
+  ? createClient(supabaseUrl, supabaseAnonKey, {
+      auth: {
+        persistSession: true,
+        autoRefreshToken: true,
+        storageKey: 'car-detective-auth-storage',
+      },
+    })
+  : null;
+
+function mapToLegacyResponse(data: NormalizedValuationResponse | null | undefined): AinResponse {
+  const finalValue = data?.finalValue ?? 0;
+  const priceRange = (data?.priceRange && data.priceRange.length === 2)
+    ? [data.priceRange[0] ?? 0, data.priceRange[1] ?? 0] as [number, number]
+    : [0, 0];
+  const confidenceScore = data?.confidenceScore ?? 0;
+  const adjustments = data?.adjustments ?? [];
+
+  const marketData: Record<string, unknown> = data?.market_data ? { ...data.market_data } : {};
+  if (data?.marketListingsCount !== undefined) {
+    marketData.market_listings_count = data.marketListingsCount;
+  }
+  if (data?.sourcesUsed) {
+    marketData.sources_used = data.sourcesUsed;
+  }
+
+  return {
+    finalValue,
+    priceRange,
+    confidenceScore,
+    adjustments,
+    explanation: data?.explanation,
+    marketListingsCount: data?.marketListingsCount,
+    sourcesUsed: data?.sourcesUsed,
+    estimated_value: finalValue,
+    confidence_score: confidenceScore,
+    price_range_low: priceRange[0],
+    price_range_high: priceRange[1],
+    price_range: priceRange,
+    breakdown: adjustments,
+    market_data: Object.keys(marketData).length ? marketData : undefined,
+    base_value: data?.baseValue ?? finalValue,
+  };
+}
 
 export async function runValuation(payload: {
   vin?: string;
@@ -28,30 +89,29 @@ export async function runValuation(payload: {
   condition: "poor" | "fair" | "good" | "very_good" | "excellent";
   requested_by?: string;
 }): Promise<{ data: AinResponse; meta: AinMeta }> {
+  if (!supabase) {
+    throw new Error('Supabase environment not configured');
+  }
   const corrId = crypto.randomUUID();
-  const res = await fetch('/functions/v1/valuation', {
-    method: 'POST',
-    headers: { 
-      'content-type': 'application/json', 
-      'x-correlation-id': corrId 
-    },
-    body: JSON.stringify(payload),
+  const { data, error } = await supabase.functions.invoke<NormalizedValuationResponse>('ain-valuation', {
+    body: payload,
+    headers: { 'x-correlation-id': corrId },
   });
 
   const meta: AinMeta = {
-    route: res.headers.get('x-ain-route') ?? undefined,
-    corr_id: res.headers.get('x-correlation-id'),
-    upstream_status: res.headers.get('x-upstream-status'),
+    route: 'ain-valuation',
+    corr_id: corrId,
+    upstream_status: null,
   };
 
-  // Signals for QA tools and Playwright
-  if (res.ok) console.log('ain.ok');
-  console.log('ain.route', { ok: res.ok, ...meta });
-
-  if (!res.ok) {
-    const body = await res.text().catch(() => '');
-    throw new Error(`valuation_failed route=${meta.route} status=${res.status} corr_id=${meta.corr_id} body=${body}`);
+  if (error) {
+    console.log('ain.route', { ok: false, ...meta });
+    throw new Error(`valuation_failed corr_id=${corrId} detail=${error.message}`);
   }
 
-  return { data: await res.json() as AinResponse, meta };
+  console.log('ain.ok');
+  console.log('ain.route', { ok: true, ...meta });
+
+  return { data: mapToLegacyResponse(data), meta };
 }
+

--- a/src/pages/api/valuation/submit-followup.ts
+++ b/src/pages/api/valuation/submit-followup.ts
@@ -11,7 +11,7 @@ export default async function submitFollowUp(followUpData: FollowUpAnswers) {
 
     // Create a valuation record first
     const { data: valuation, error: valuationError } = await supabase
-      .from('valuations')
+      .from('valuation_results')
       .insert({
         vin: followUpData.vin,
         zip_code: followUpData.zip_code,
@@ -20,7 +20,8 @@ export default async function submitFollowUp(followUpData: FollowUpAnswers) {
         estimated_value: 25000, // This would be calculated based on the follow-up data
         confidence_score: 85,
         user_id: null, // For now, allowing anonymous submissions
-        created_at: new Date().toISOString()
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString()
       })
       .select('id')
       .single();

--- a/src/utils/diagnostics/systemHealth.ts
+++ b/src/utils/diagnostics/systemHealth.ts
@@ -16,7 +16,7 @@ export async function runSystemHealthCheck(): Promise<SystemHealthCheck[]> {
   const dbStart = performance.now();
   try {
     const { data, error } = await supabase
-      .from('valuations')
+      .from('valuation_results')
       .select('count')
       .limit(1);
     
@@ -46,8 +46,8 @@ export async function runSystemHealthCheck(): Promise<SystemHealthCheck[]> {
 
   // 2. Check critical tables exist and have data
   const criticalTables = [
-    'valuations',
-    'decoded_vehicles', 
+    'valuation_results',
+    'decoded_vehicles',
     'auction_results_by_vin',
     'scraped_listings',
     'follow_up_answers'
@@ -85,7 +85,7 @@ export async function runSystemHealthCheck(): Promise<SystemHealthCheck[]> {
   try {
     const yesterday = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
     const { count } = await supabase
-      .from('valuations')
+      .from('valuation_results')
       .select('*', { count: 'exact', head: true })
       .gte('created_at', yesterday);
 

--- a/src/utils/diagnostics/valuationAudit.ts
+++ b/src/utils/diagnostics/valuationAudit.ts
@@ -24,7 +24,7 @@ export async function runValuationAudit(vin: string): Promise<AuditResult> {
     }
 
     const { data: valuation, error: valErr } = await supabase
-      .from('valuations')
+      .from('valuation_results')
       .select('*')
       .eq('vin', vin)
       .order('created_at', { ascending: false })

--- a/src/utils/validation/validateCorrectedPipeline.ts
+++ b/src/utils/validation/validateCorrectedPipeline.ts
@@ -16,7 +16,7 @@ export async function validateCorrectedPipeline(vin: string) {
   try {
     // Check updated valuation record
     const { data: valuation } = await supabase
-      .from('valuations')
+      .from('valuation_results')
       .select('*')
       .eq('vin', vin)
       .single();


### PR DESCRIPTION
## Summary
- update the browser valuation client to call the ain-valuation function via Supabase auth and map normalized fields to legacy consumers
- persist follow-up and rerun flows to the valuation_results table while reading the new response shape across the UI
- retarget diagnostics, helpers, and scripts to valuation_results and fix the audit script import for typechecking

## Testing
- npm run typecheck
- npm run build


------
https://chatgpt.com/codex/tasks/task_b_68cd9415f82c832d87b01cb81567cd73